### PR TITLE
Fix YouTube embeds for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,7 +24,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Building site
-        run: JEKYLL_ENV=production bundle exec jekyll build --profile ben--trace
+        run: JEKYLL_ENV=production bundle exec jekyll build
         env:
           GISCUS_DATA_REPO_ID: ${{ secrets.GISCUS_DATA_REPO_ID }}
           GISCUS_GISCUS_DATA_CATEGORY_ID: ${{ secrets.GISCUS_DATA_REPO_ID }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cesarsotovalero.net
 
-[![jekyll](https://github.com/cesarsotovalero/cesarsotovalero.github.io/actions/workflows/workflow.yml/badge.svg)](https://github.com/cesarsotovalero/cesarsotovalero.github.io/actions/workflows/pages/pages-build-deployment)
+[![deploy](https://github.com/cesarsotovalero/cesarsotovalero.github.io/actions/workflows/deploy-website.yml/badge.svg)](https://github.com/cesarsotovalero/cesarsotovalero.github.io/actions/workflows/deploy-website.yml)
 
 This is the source code of [cesarsotovalero.net](https://www.cesarsotovalero.net), my personal website and blog.
 The repo contains a mess of HTML templates, Jekyll templates, blog posts and images, so it's been released under a dual license.

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,3 @@
+<div class="youtube-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ include.id }}" title="YouTube video" frameborder="0" allowfullscreen></iframe>
+</div>

--- a/_posts/2017/2017-10-26-how-i-beat-the-ielts-academic-with-just-a-month-of-self-training.md
+++ b/_posts/2017/2017-10-26-how-i-beat-the-ielts-academic-with-just-a-month-of-self-training.md
@@ -19,7 +19,7 @@ The International English Language Testing System (IELTS) is one of the major En
 It is jointly managed by the British Council, IELTS Australia, and Cambridge English Language Assessment.
 IELTS is accepted by most Australian, British, Canadian, and New Zealand academic institutions, by over 3,000 educational institutions in the United States, and by many professional organizations across the world.
 
-{% youtube GRd2nxNTZDI %}
+{% include youtube.html id="GRd2nxNTZDI" %}
 
 There are two versions of the test, **IELTS Academic** and **IELTS General Training**.
 The first is intended for those who want to enroll in universities and other institutions for higher education, while the latter is for test-takers who want to work, study at a secondary school, or migrate to an English-speaking country.

--- a/_posts/2021/2021-10-11-the-software-supply-chain.md
+++ b/_posts/2021/2021-10-11-the-software-supply-chain.md
@@ -20,7 +20,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube mp_jSfUACrs %}
+{% include youtube.html id="mp_jSfUACrs" %}
 
 The software supply chain comprises all the technology involved in shipping a piece of code from development to its deployment in a production environment.
 Several actors and different technologies participate in this complex process, e.g., developers, IDEs, compilers, package managers, and so on.

--- a/_posts/2021/2021-10-21-seven-reasons-to-go-for-a-phd-in-computer-science.md
+++ b/_posts/2021/2021-10-21-seven-reasons-to-go-for-a-phd-in-computer-science.md
@@ -20,7 +20,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube IrFS2e-4gqU %}
+{% include youtube.html id="IrFS2e-4gqU" %}
 
 Pursuing a PhD is a unique and personal experience.
 Admittedly, it is a journey ~~mostly~~ driven by personal ambitions and pride.

--- a/_posts/2021/2021-11-07-how-i-overcome-writer-block-when-preparing-a-research-paper.md
+++ b/_posts/2021/2021-11-07-how-i-overcome-writer-block-when-preparing-a-research-paper.md
@@ -19,7 +19,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube TrYB4D_1flA %}
+{% include youtube.html id="TrYB4D_1flA" %}
 
 Every time I start writing a new research paper, the same freezing feeling seems to emerge when I look at the blank page.
 This problem is known as writer's block, and most academics suffer from it in one way or the other.

--- a/_posts/2022/2022-06-15-why-debloating-third-party-software.md
+++ b/_posts/2022/2022-06-15-why-debloating-third-party-software.md
@@ -19,7 +19,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube DqL3-bnSCy0 %}
+{% include youtube.html id="DqL3-bnSCy0" %}
 
 Most software applications today are built using third-party libraries and frameworks that together constitute the application's [software supply chain](../blog/the-software-supply-chain.html).
 These libraries are often large and complex pieces of engineering, with many features and functionalities to support a wide range of use cases.

--- a/_posts/2023/2023-11-12-how-i-peer-review-research-papers.md
+++ b/_posts/2023/2023-11-12-how-i-peer-review-research-papers.md
@@ -21,7 +21,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube k31h3hoV-Us %}
+{% include youtube.html id="k31h3hoV-Us" %}
 
 In academic circles, [peer reviewing](https://en.wikipedia.org/wiki/Scholarly_peer_review) is the act of assessing the quality of a research paper to determine if it's worth to be published in a journal or conference.
 Peer reviewers are supposed to be (human) experts in the field, and their opinions have direct influence on the final decision taken by the associated editor regarding accepting or rejecting a paper submission.

--- a/_posts/2023/2023-12-27-revisiting-ken-thompson-reflection-on-trusting-trust.md
+++ b/_posts/2023/2023-12-27-revisiting-ken-thompson-reflection-on-trusting-trust.md
@@ -21,7 +21,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube jdnWhkgA_rM %}
+{% include youtube.html id="jdnWhkgA_rM" %}
 
 Let me ask:
 _Would you trust a cracked version of [Adobe Photoshop](https://en.wikipedia.org/wiki/Adobe_Photoshop) downloaded from a random website?_

--- a/_posts/2024-MM-DD-todo-the-title.md
+++ b/_posts/2024-MM-DD-todo-the-title.md
@@ -95,7 +95,7 @@ TODO
   <iframe width="560" height="349" src="https://www.youtube.com/embed/IrFS2e-4gqU" title="YouTube video player" frameborder="1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-{% youtube VIDEO_ID %}
+{% include youtube.html id="VIDEO_ID" %}
 
 # External Resources
 

--- a/_posts/2024/2024-01-12-building-and-leveling-up-a-computer-scientist-resume.md
+++ b/_posts/2024/2024-01-12-building-and-leveling-up-a-computer-scientist-resume.md
@@ -21,7 +21,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube -EYVzXoq15o %}
+{% include youtube.html id="-EYVzXoq15o" %}
 
 Recently, a few friends kindly asked me to provide some feedback on their résumés. 
 They are all Computer Science PhD graduates looking to land a new job in the tech industry. 

--- a/_posts/2024/2024-05-05-the-last-paper-myth.md
+++ b/_posts/2024/2024-05-05-the-last-paper-myth.md
@@ -21,7 +21,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube -3txwKTHe4Y %}
+{% include youtube.html id="-3txwKTHe4Y" %}
 
 Last week, I met a colleague from a renowned research lab.
 She is currently doing the last year of her PhD.

--- a/_posts/2024/2024-07-13-the-not-so-strange-case-of-cargo-cult-in-computer-science-research.md
+++ b/_posts/2024/2024-07-13-the-not-so-strange-case-of-cargo-cult-in-computer-science-research.md
@@ -21,7 +21,7 @@ author: cesarsotovalero
 published: true
 ---
 
-{% youtube N7pY8VAt6g4 %}
+{% include youtube.html id="N7pY8VAt6g4" %}
 
 Everywhere, I see computer scientists that look like they are working on the right thing. 
 They spent a long time doing the thing, writing code to run it (in the best cases), and collecting results.

--- a/_posts/2024/2024-08-19-why-genai-will-not-replace-software-engineers-just-yet.md
+++ b/_posts/2024/2024-08-19-why-genai-will-not-replace-software-engineers-just-yet.md
@@ -25,7 +25,7 @@ The field of Generative Artificial Intelligence (GenAI) has made incredible stri
 The excitement is well justified.  
 Today's GenAI systems can perform common software development tasks more efficiently than many human engineers.
 
-{% youtube kw7fvHf4rDw %}
+{% include youtube.html id="kw7fvHf4rDw" %}
 
 I've experienced the power of this technology firsthand.  
 [ChatGPT-4o](https://chatgpt.com/?model=gpt-4o) is truly impressive at fixing bugs, refactoring code, and even adding entirely new features to my software projects.  


### PR DESCRIPTION
## Summary
- avoid the custom Liquid tag by using a simple include for YouTube videos
- replace `{% youtube ... %}` with `{% include youtube.html %}` in posts

## Testing
- ❌ `bundle exec jekyll build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e4f0475483278dc12b783eaf70e6