### PR TITLE
Improve booking page typography and CTA buttons

### DIFF
--- a/css/booking.css
+++ b/css/booking.css
@@ -2,7 +2,8 @@
   max-width: 1120px;
   margin: 0 auto;
   padding: 28px 16px 56px;
-  font-size: 1.04rem;
+  font-family: "Century Supra T4", "Georgia", "Times New Roman", serif;
+  font-size: 16px;
 }
 
 .booking-hero {
@@ -42,8 +43,9 @@
 
 .booking-eyebrow {
   margin: 0 0 6px;
-  font-family: "Concourse T4", "Linux Biolinum", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 0.94rem;
+  font-family: "Concourse T6 Tab", "Concourse T6", "Open Sans", sans-serif;
+  font-size: 0.78em;
+  font-weight: 700;
   letter-spacing: 0.09em;
   text-transform: uppercase;
   opacity: 0.75;
@@ -51,13 +53,15 @@
 
 .booking-hero h1 {
   margin: 0 0 10px;
-  font-size: clamp(2.2rem, 3.2vw, 3rem);
+  font-family: "Concourse T6", "Concourse T4", "Open Sans", sans-serif;
+  font-size: clamp(2.2em, 4vw, 3.1em);
+  font-weight: 700;
   line-height: 1.1;
 }
 
 .booking-subtitle {
   margin: 0;
-  font-size: 1.18rem;
+  font-size: 1.18em;
   line-height: 1.65;
   color: var(--main-text-color);
   opacity: 0.92;
@@ -76,7 +80,7 @@
   margin: 0;
   padding-left: 1.4em;
   line-height: 1.45;
-  font-size: 1.04rem;
+  font-size: 1em;
 }
 
 .booking-hero-highlights li::before {
@@ -117,8 +121,9 @@
 }
 
 .booking-social-link span {
-  font-family: "Concourse T4", "Linux Biolinum", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 0.92rem;
+  font-family: "Concourse T4", "Open Sans", sans-serif;
+  font-size: 0.86em;
+  font-weight: 700;
   letter-spacing: 0.02em;
 }
 
@@ -157,13 +162,15 @@
 
 .booking-proof-strip h2 {
   margin: 0 0 8px;
-  font-size: 1.14rem;
+  font-family: "Concourse T6", "Concourse T4", "Open Sans", sans-serif;
+  font-size: 1.08em;
+  font-weight: 700;
   line-height: 1.25;
 }
 
 .booking-proof-strip p {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: 1.02em;
   line-height: 1.5;
   opacity: 0.9;
 }
@@ -178,12 +185,14 @@
 
 .booking-section-header h2 {
   margin: 0 0 6px;
-  font-size: 1.72rem;
+  font-family: "Concourse T6", "Concourse T4", "Open Sans", sans-serif;
+  font-size: 1.75em;
+  font-weight: 700;
 }
 
 .booking-section-header p {
   margin: 0;
-  font-size: 1.08rem;
+  font-size: 1.08em;
   opacity: 0.9;
 }
 
@@ -241,7 +250,9 @@
 
 .booking-card h3 {
   margin: 0;
-  font-size: 1.34rem;
+  font-family: "Concourse T6", "Concourse T4", "Open Sans", sans-serif;
+  font-size: 1.28em;
+  font-weight: 700;
   line-height: 1.25;
 }
 
@@ -251,21 +262,23 @@
   border: 1px solid var(--panel-border-color);
   border-radius: 999px;
   padding: 4px 10px;
-  font-family: "Concourse T4", "Linux Biolinum", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 0.78rem;
+  font-family: "Concourse T6 Tab", "Concourse T6", "Open Sans", sans-serif;
+  font-size: 0.7em;
+  font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   white-space: nowrap;
   background: rgba(66, 103, 178, 0.14);
 }
 
-.booking-card-meta {
+.booking-card > .booking-card-meta {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 8px;
   margin: 0;
-  font-size: 1rem;
+  font-family: "Concourse T4", "Open Sans", sans-serif;
+  font-size: 0.86em;
   font-weight: 700;
   color: var(--heading-color);
   opacity: 0.9;
@@ -274,7 +287,7 @@
 .booking-card > p {
   margin: 0;
   line-height: 1.55;
-  font-size: 1.06rem;
+  font-size: 1.06em;
 }
 
 .booking-card-benefits {
@@ -288,24 +301,28 @@
 
 .booking-card-benefits li {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: 0.98em;
 }
 
 .booking-cta {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   margin-top: 2px;
-  padding: 12px 15px;
-  border-radius: 10px;
+  min-height: 48px;
+  padding: 12px 18px;
+  border-radius: 12px;
   border: 1px solid var(--button-background-color);
   background: var(--button-background-color);
   color: var(--button-text-color) !important;
   text-align: center;
   text-decoration: none !important;
-  font-family: "Concourse T4", "Linux Biolinum", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: "Concourse T6", "Concourse T4", "Open Sans", sans-serif;
+  font-size: 1.02em;
   font-weight: 700;
-  font-size: 1rem;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.14);
   transition: transform 0.15s ease, opacity 0.15s ease, box-shadow 0.2s ease;
 }
 
@@ -329,9 +346,10 @@
   padding: 12px 28px;
 }
 
-.booking-card-small {
+.booking-card > .booking-card-small {
   margin: 0;
-  font-size: 0.9rem;
+  font-family: "Concourse T3", "Concourse T4", "Open Sans", sans-serif;
+  font-size: 0.78em;
   line-height: 1.35;
   opacity: 0.8;
 }
@@ -362,7 +380,7 @@
 
 .booking-quote-role {
   display: block;
-  font-size: 0.98rem;
+  font-size: 0.98em;
   opacity: 0.85;
 }
 
@@ -379,7 +397,7 @@
 .booking-faq-item h3 {
   margin-top: 0;
   margin-bottom: 6px;
-  font-size: 1.14rem;
+  font-size: 1.14em;
 }
 
 .booking-faq-item p {
@@ -471,7 +489,7 @@
   }
 
   .booking-social-link span {
-    font-size: 0.86rem;
+    font-size: 0.82em;
   }
 }
 


### PR DESCRIPTION
## Summary
- establish a distinct typography hierarchy for the booking page using the site's existing Century Supra and Concourse font families
- tune heading, body, metadata, and supporting text sizes for desktop and mobile readability
- style booking CTAs as accessible, full-width buttons with a 48px touch target, hover feedback, and focus-friendly contrast

## Validation
- `git diff --check`
- Chrome MCP mobile check at 390px: no horizontal overflow and no CTA text overflow
- Confirmed loaded fonts and computed sizes for body copy, metadata, payment notes, and buttons

## Environment note
- `bundle exec jekyll build` remains unavailable in this environment because the installed Bundler is incompatible with system Ruby 2.6 (`Gem::Resolver::APISet::GemParser`).